### PR TITLE
Create base template. Index extends base

### DIFF
--- a/pdxpython/templates/base.html
+++ b/pdxpython/templates/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>PDX-Python</title>
+    <meta charset="utf-8">
+    {% load staticfiles %}
+    <link rel="stylesheet" type="text/css" href="{% static "style.css" %}" />
+  </head>
+  <body>
+    <div class="container">
+      <div id="top-nav">
+      {% block topnav %}top nav{% endblock %}
+      </div>
+
+      <div id="left-nav">
+      {% block leftnav %}left nav{% endblock %}
+      </div>
+
+      <div id="body">
+      {% block body %}body{% endblock %}
+      </div>
+
+      <div id="footer">
+      {% block footer %}footer{% endblock %}
+      </div>
+
+    </div> <!-- container -->
+
+    {% block postcontainer %}{% endblock %}
+
+  </body>
+</html>

--- a/pdxpython/templates/index.html
+++ b/pdxpython/templates/index.html
@@ -1,40 +1,21 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>PDX-Python</title>
-    <meta charset="utf-8">
-    {% load staticfiles %}
-    <link rel="stylesheet" type="text/css" href="{% static "style.css" %}" />
-  </head>
-  <body>
-    <div class="container">
-      <div id="top-nav">
-        <ul class="nav">
-          <li><a href="#">home</a></li>
-          <li><a href="#">recent talks</a></li>
-          <li><a href="#">propose a talk</a></li>
-          <li><a href="#">community</a></li>
-        </ul>
-      </div>
+{% extends "base.html" %}
 
-      <div id="left-nav">
-        <ul class="nav">
-          <li><a href="#">G+</a></li>
-          <li><a href="#">Github</a></li>
-          <li><a href="#">Meetup</a></li>
-          <li><a href="#">Twitter</a></li>
-          <li><a href="#">Wiki</a></li>
-        </ul>
-      </div>
+{% block topnav %}
+{% include "nav/topnav.html" %}
+{% endblock %}
 
+{% block leftnav %}
+{% include "nav/leftnav.html" %}
+{% endblock %}
+
+{% block body %}
       <div id="calendar">
       </div>
+{% endblock %}
 
-      <div id="footer">
-        footer
-      </div>
+{# no footer block yet #}
 
-    </div> <!-- container -->
+{% block postcontainer %}
     <script src="static/module.js" type="text/javascript"></script>
       {% verbatim %}
     <script id="calendarTemplate" type="text/template">
@@ -58,5 +39,4 @@
       {{/events}}
     </script>
       {% endverbatim %}
-  </body>
-</html>
+{% endblock %}

--- a/pdxpython/templates/nav/leftnav.html
+++ b/pdxpython/templates/nav/leftnav.html
@@ -1,0 +1,7 @@
+        <ul class="nav">
+          <li><a href="#">G+</a></li>
+          <li><a href="#">Github</a></li>
+          <li><a href="#">Meetup</a></li>
+          <li><a href="#">Twitter</a></li>
+          <li><a href="#">Wiki</a></li>
+        </ul>

--- a/pdxpython/templates/nav/topnav.html
+++ b/pdxpython/templates/nav/topnav.html
@@ -1,0 +1,6 @@
+        <ul class="nav">
+          <li><a href="#">home</a></li>
+          <li><a href="#">recent talks</a></li>
+          <li><a href="#">propose a talk</a></li>
+          <li><a href="#">community</a></li>
+        </ul>


### PR DESCRIPTION
-  Create base.html template with template blocks for top nav, left nav, body, footer, and postcontainer to allow adding pages with left nav, top nav, footer in common with index.html
  -- Create leftnav.html, topnav.html in new templates/nav directory
  -- Modify index.html to extend from new base.html.  Calendar moved to body block, calendar scripting moved to postcontainer block
